### PR TITLE
Add Gradio dashboard

### DIFF
--- a/Character-Generator/app.py
+++ b/Character-Generator/app.py
@@ -122,4 +122,8 @@ with gr.Blocks(title="Character Generator") as app:
         get_random_persona_description, outputs=[persona_description]
     )
 
-app.queue().launch(share=False)
+def create_app():
+    return app
+
+if __name__ == "__main__":
+    app.queue().launch(share=False)

--- a/FLUX-LoRA-DLC/app.py
+++ b/FLUX-LoRA-DLC/app.py
@@ -2417,5 +2417,9 @@ with gr.Blocks(theme=gr.themes.Soft(), css=css, delete_cache=(60, 60)) as app:
         outputs=[result, seed, progress_bar]
     )
 
-app.queue()
-app.launch(mcp_server=True, ssr_mode=False, show_error=True)
+def create_app():
+    return app
+
+if __name__ == "__main__":
+    app.queue()
+    app.launch(mcp_server=True, ssr_mode=False, show_error=True)

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,34 @@
+import gradio as gr
+import importlib.util
+import os
+
+
+def load_create_app(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.create_app
+
+character_create_app = load_create_app('character_generator', os.path.join('Character-Generator', 'app.py'))
+flux_create_app = load_create_app('flux_lora_dlc', os.path.join('FLUX-LoRA-DLC', 'app.py'))
+faceswap_create_app = load_create_app('faceswap', os.path.join('faceswap', 'app.py'))
+selfforcing_create_app = load_create_app('self_forcing', os.path.join('self-forcing', 'app.py'))
+
+apps = [
+    character_create_app(),
+    flux_create_app(),
+    faceswap_create_app(),
+    selfforcing_create_app(),
+]
+labels = [
+    'Character Generator',
+    'FLUX LoRA DLC',
+    'FaceSwap',
+    'Self-Forcing',
+]
+
+demo = gr.TabbedInterface(apps, labels)
+
+if __name__ == '__main__':
+    demo.queue().launch()
+

--- a/faceswap/app.py
+++ b/faceswap/app.py
@@ -888,8 +888,12 @@ with gr.Blocks(css=css) as interface:
         lambda: open_directory(path=OUTPUT_FILE), inputs=None, outputs=None
     )
 
+def create_app():
+    return interface
+
 if __name__ == "__main__":
     if USE_COLAB:
         print("Running in colab mode")
 
     interface.queue(concurrency_count=2, max_size=20).launch(share=USE_COLAB)
+

--- a/self-forcing/app.py
+++ b/self-forcing/app.py
@@ -503,20 +503,23 @@ with gr.Blocks(title="Self-Forcing Streaming Demo") as demo:
     )
 
 # --- Launch App ---
+def create_app():
+    return demo
+
 if __name__ == "__main__":
     if os.path.exists("gradio_tmp"):
         import shutil
         shutil.rmtree("gradio_tmp")
     os.makedirs("gradio_tmp", exist_ok=True)
-    
+
     print("🚀 Starting Self-Forcing Streaming Demo")
     print(f"📁 Temporary files will be stored in: gradio_tmp/")
     print(f"🎯 Chunk encoding: PyAV (MPEG-TS/H.264)")
     print(f"⚡ GPU acceleration: {gpu}")
-    
+
     demo.queue().launch(
-        server_name=args.host, 
-        server_port=args.port, 
+        server_name=args.host,
+        server_port=args.port,
         share=args.share,
         show_error=True,
         max_threads=40,


### PR DESCRIPTION
## Summary
- add a new `dashboard.py` that loads sub-apps and creates tabs
- expose `create_app()` in each gradio app so they can be combined

## Testing
- `python -m py_compile Character-Generator/app.py FLUX-LoRA-DLC/app.py faceswap/app.py self-forcing/app.py dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_6865959c4bf083309643a14151e9a31d