### PR TITLE
Create-app wrapper for launch patterns

### DIFF
--- a/Character-Generator/app.py
+++ b/Character-Generator/app.py
@@ -8,6 +8,8 @@ import spaces
 from google import genai
 from pydantic import BaseModel
 
+__all__ = ["create_app"]
+
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # Initialize Google Gemini API client
@@ -87,43 +89,43 @@ app_description = """
 **Note:** I recommend starting with the world description (you can write one or loop over randomly generated ones) and then try different persona descriptions to generate interesting characters for the world you created.
 """
 
-with gr.Blocks(title="Character Generator") as app:
-    with gr.Column():
-        gr.HTML("<center><h1>Character Generator</h1></center>")
-        gr.Markdown(app_description.strip())
-        with gr.Column():
-            with gr.Row():
-                world_description = gr.Textbox(lines=10, label="World Description", scale=4)
-                persona_description = gr.Textbox(lines=10, label="Persona Description", value=get_random_persona_description(), scale=1)
-            with gr.Row(equal_height=True):
-                random_world_button = gr.Button(value="Get Random World Description", variant="secondary", scale=1)
-                submit_button = gr.Button(value="Generate Interesting Character!", variant="primary", scale=5)
-                random_persona_button = gr.Button(value="Get Random Persona Description", variant="secondary", scale=1)
-        with gr.Row(equal_height=True):
-            character_image = gr.Image(label="Character Image", height=1024, width=1024)
-            character_json = gr.JSON(label="Character Description")
-
-        examples = gr.Examples(
-            [
-                "In a world where magic is real and dragons roam the skies, a group of adventurers set out to find the legendary sword of the dragon king.",
-                "Welcome to Aethoria, a vast and mysterious realm where the laws of physics bend to the will of ancient magic. This world is comprised of countless floating islands suspended in an endless sky, each one a unique ecosystem teeming with life and secrets. The islands of Aethoria range from lush, verdant jungles to barren, crystalline deserts. Some are no larger than a city block, while others span hundreds of miles. Connecting these disparate landmasses are shimmering bridges of pure energy, and those brave enough to venture off the beaten path can find hidden portals that instantly transport them across great distances. Aethoria's inhabitants are as diverse as its landscapes. Humans coexist with ethereal beings of light, rock-skinned giants, and shapeshifting creatures that defy classification. Ancient ruins dot the islands, hinting at long-lost civilizations and forgotten technologies that blur the line between science and sorcery. The world is powered by Aether, a mystical substance that flows through everything. Those who can harness its power become formidable mages, capable of manipulating reality itself. However, Aether is a finite resource, and its scarcity has led to conflicts between the various factions vying for control. In the skies between the islands, magnificent airships sail on currents of magic, facilitating trade and exploration. Pirates and sky raiders lurk in the cloudy depths, always on the lookout for unsuspecting prey. Deep beneath the floating lands lies the Undervoid, a dark and treacherous realm filled with nightmarish creatures and untold riches. Only the bravest adventurers dare to plumb its depths, and fewer still return to tell the tale. As an ever-present threat, the Chaos Storms rage at the edges of the known world, threatening to consume everything in their path. It falls to the heroes of Aethoria to uncover the secrets of their world and find a way to push back the encroaching darkness before it's too late. In Aethoria, every island holds a story, every creature has a secret, and every adventure could change the fate of this wondrous, imperiled world.",
-                "In a world from my imagination, there is a city called 'Orakis'. floating in the sky on pillars of pure light. The walls of the city are made of crystal glass, constantly reflecting the colors of dawn and dusk, giving it an eternal celestial glow. The buildings breathe and change their shapes according to the seasons—they grow in spring, strengthen in summer, and begin to fade in autumn until they become mist in winter.",
-            ],
-            world_description,
-        )
-
-    submit_button.click(
-        generate_character, [world_description, persona_description], outputs=[character_json]
-    ).then(fn=infer_flux, inputs=[character_json], outputs=[character_image])
-    random_world_button.click(
-        get_random_world_description, outputs=[world_description]
-    )
-    random_persona_button.click(
-        get_random_persona_description, outputs=[persona_description]
-    )
-
 def create_app():
+    with gr.Blocks(title="Character Generator") as app:
+        with gr.Column():
+            gr.HTML("<center><h1>Character Generator</h1></center>")
+            gr.Markdown(app_description.strip())
+            with gr.Column():
+                with gr.Row():
+                    world_description = gr.Textbox(lines=10, label="World Description", scale=4)
+                    persona_description = gr.Textbox(lines=10, label="Persona Description", value=get_random_persona_description(), scale=1)
+                with gr.Row(equal_height=True):
+                    random_world_button = gr.Button(value="Get Random World Description", variant="secondary", scale=1)
+                    submit_button = gr.Button(value="Generate Interesting Character!", variant="primary", scale=5)
+                    random_persona_button = gr.Button(value="Get Random Persona Description", variant="secondary", scale=1)
+            with gr.Row(equal_height=True):
+                character_image = gr.Image(label="Character Image", height=1024, width=1024)
+                character_json = gr.JSON(label="Character Description")
+    
+            examples = gr.Examples(
+                [
+                    "In a world where magic is real and dragons roam the skies, a group of adventurers set out to find the legendary sword of the dragon king.",
+                    "Welcome to Aethoria, a vast and mysterious realm where the laws of physics bend to the will of ancient magic. This world is comprised of countless floating islands suspended in an endless sky, each one a unique ecosystem teeming with life and secrets. The islands of Aethoria range from lush, verdant jungles to barren, crystalline deserts. Some are no larger than a city block, while others span hundreds of miles. Connecting these disparate landmasses are shimmering bridges of pure energy, and those brave enough to venture off the beaten path can find hidden portals that instantly transport them across great distances. Aethoria's inhabitants are as diverse as its landscapes. Humans coexist with ethereal beings of light, rock-skinned giants, and shapeshifting creatures that defy classification. Ancient ruins dot the islands, hinting at long-lost civilizations and forgotten technologies that blur the line between science and sorcery. The world is powered by Aether, a mystical substance that flows through everything. Those who can harness its power become formidable mages, capable of manipulating reality itself. However, Aether is a finite resource, and its scarcity has led to conflicts between the various factions vying for control. In the skies between the islands, magnificent airships sail on currents of magic, facilitating trade and exploration. Pirates and sky raiders lurk in the cloudy depths, always on the lookout for unsuspecting prey. Deep beneath the floating lands lies the Undervoid, a dark and treacherous realm filled with nightmarish creatures and untold riches. Only the bravest adventurers dare to plumb its depths, and fewer still return to tell the tale. As an ever-present threat, the Chaos Storms rage at the edges of the known world, threatening to consume everything in their path. It falls to the heroes of Aethoria to uncover the secrets of their world and find a way to push back the encroaching darkness before it's too late. In Aethoria, every island holds a story, every creature has a secret, and every adventure could change the fate of this wondrous, imperiled world.",
+                    "In a world from my imagination, there is a city called 'Orakis'. floating in the sky on pillars of pure light. The walls of the city are made of crystal glass, constantly reflecting the colors of dawn and dusk, giving it an eternal celestial glow. The buildings breathe and change their shapes according to the seasons—they grow in spring, strengthen in summer, and begin to fade in autumn until they become mist in winter.",
+                ],
+                world_description,
+            )
+    
+        submit_button.click(
+            generate_character, [world_description, persona_description], outputs=[character_json]
+        ).then(fn=infer_flux, inputs=[character_json], outputs=[character_image])
+        random_world_button.click(
+            get_random_world_description, outputs=[world_description]
+        )
+        random_persona_button.click(
+            get_random_persona_description, outputs=[persona_description]
+        )
     return app
 
+
 if __name__ == "__main__":
-    app.queue().launch(share=False)
+    create_app().queue().launch(share=False)

--- a/FLUX-LoRA-DLC/app.py
+++ b/FLUX-LoRA-DLC/app.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List, Optional, Union
 import torch
 from PIL import Image
 import gradio as gr
+__all__ = ["create_app"]
+
 
 from diffusers import (
     DiffusionPipeline,
@@ -2346,80 +2348,79 @@ css = '''
 .progress-bar {height: 100%;background-color: #4f46e5;width: calc(var(--current) / var(--total) * 100%);transition: width 0.5s ease-in-out}
 '''
 
-with gr.Blocks(theme=gr.themes.Soft(), css=css, delete_cache=(60, 60)) as app:
-    title = gr.HTML(
-        """<h1>FLUX LoRA DLC🥳</h1>""",
-        elem_id="title",
-    )
-    selected_index = gr.State(None)
-    with gr.Row():
-        with gr.Column(scale=3):
-            prompt = gr.Textbox(label="Prompt", lines=1, placeholder=":/ choose the LoRA and type the prompt ")
-        with gr.Column(scale=1, elem_id="gen_column"):
-            generate_button = gr.Button("Generate", variant="primary", elem_id="gen_btn")
-    with gr.Row():
-        with gr.Column():
-            selected_info = gr.Markdown("")
-            gallery = gr.Gallery(
-                [(item["image"], item["title"]) for item in loras],
-                label="250+ LoRA DLC's",
-                allow_preview=False,
-                columns=3,
-                elem_id="gallery",
-                show_share_button=False
-            )
-            with gr.Group():
-                custom_lora = gr.Textbox(label="Enter Custom LoRA", placeholder="prithivMLmods/Canopus-LoRA-Flux-Anime")
-                gr.Markdown("[Check the list of FLUX LoRA's](https://huggingface.co/models?other=base_model:adapter:black-forest-labs/FLUX.1-dev)", elem_id="lora_list")
-            custom_lora_info = gr.HTML(visible=False)
-            custom_lora_button = gr.Button("Remove custom LoRA", visible=False)
-        with gr.Column():
-            progress_bar = gr.Markdown(elem_id="progress",visible=False)
-            result = gr.Image(label="Generated Image", format="png")
-
-    with gr.Row():
-        with gr.Accordion("Advanced Settings", open=False):
-            with gr.Row():
-                input_image = gr.Image(label="Input image", type="filepath")
-                image_strength = gr.Slider(label="Denoise Strength", info="Lower means more image influence", minimum=0.1, maximum=1.0, step=0.01, value=0.75)
-            with gr.Column():
-                with gr.Row():
-                    cfg_scale = gr.Slider(label="CFG Scale", minimum=1, maximum=20, step=0.5, value=3.5)
-                    steps = gr.Slider(label="Steps", minimum=1, maximum=50, step=1, value=28)
-                
-                with gr.Row():
-                    width = gr.Slider(label="Width", minimum=256, maximum=1536, step=64, value=1024)
-                    height = gr.Slider(label="Height", minimum=256, maximum=1536, step=64, value=1024)
-                
-                with gr.Row():
-                    randomize_seed = gr.Checkbox(True, label="Randomize seed")
-                    seed = gr.Slider(label="Seed", minimum=0, maximum=MAX_SEED, step=1, value=0, randomize=True)
-                    lora_scale = gr.Slider(label="LoRA Scale", minimum=0, maximum=3, step=0.01, value=0.95)
-
-    gallery.select(
-        update_selection,
-        inputs=[width, height],
-        outputs=[prompt, selected_info, selected_index, width, height]
-    )
-    custom_lora.input(
-        add_custom_lora,
-        inputs=[custom_lora],
-        outputs=[custom_lora_info, custom_lora_button, gallery, selected_info, selected_index, prompt]
-    )
-    custom_lora_button.click(
-        remove_custom_lora,
-        outputs=[custom_lora_info, custom_lora_button, gallery, selected_info, selected_index, custom_lora]
-    )
-    gr.on(
-        triggers=[generate_button.click, prompt.submit],
-        fn=run_lora,
-        inputs=[prompt, input_image, image_strength, cfg_scale, steps, selected_index, randomize_seed, seed, width, height, lora_scale],
-        outputs=[result, seed, progress_bar]
-    )
-
 def create_app():
+    with gr.Blocks(theme=gr.themes.Soft(), css=css, delete_cache=(60, 60)) as app:
+        title = gr.HTML(
+            """<h1>FLUX LoRA DLC🥳</h1>""",
+            elem_id="title",
+        )
+        selected_index = gr.State(None)
+        with gr.Row():
+            with gr.Column(scale=3):
+                prompt = gr.Textbox(label="Prompt", lines=1, placeholder=":/ choose the LoRA and type the prompt ")
+            with gr.Column(scale=1, elem_id="gen_column"):
+                generate_button = gr.Button("Generate", variant="primary", elem_id="gen_btn")
+        with gr.Row():
+            with gr.Column():
+                selected_info = gr.Markdown("")
+                gallery = gr.Gallery(
+                    [(item["image"], item["title"]) for item in loras],
+                    label="250+ LoRA DLC's",
+                    allow_preview=False,
+                    columns=3,
+                    elem_id="gallery",
+                    show_share_button=False
+                )
+                with gr.Group():
+                    custom_lora = gr.Textbox(label="Enter Custom LoRA", placeholder="prithivMLmods/Canopus-LoRA-Flux-Anime")
+                    gr.Markdown("[Check the list of FLUX LoRA's](https://huggingface.co/models?other=base_model:adapter:black-forest-labs/FLUX.1-dev)", elem_id="lora_list")
+                custom_lora_info = gr.HTML(visible=False)
+                custom_lora_button = gr.Button("Remove custom LoRA", visible=False)
+            with gr.Column():
+                progress_bar = gr.Markdown(elem_id="progress",visible=False)
+                result = gr.Image(label="Generated Image", format="png")
+    
+        with gr.Row():
+            with gr.Accordion("Advanced Settings", open=False):
+                with gr.Row():
+                    input_image = gr.Image(label="Input image", type="filepath")
+                    image_strength = gr.Slider(label="Denoise Strength", info="Lower means more image influence", minimum=0.1, maximum=1.0, step=0.01, value=0.75)
+                with gr.Column():
+                    with gr.Row():
+                        cfg_scale = gr.Slider(label="CFG Scale", minimum=1, maximum=20, step=0.5, value=3.5)
+                        steps = gr.Slider(label="Steps", minimum=1, maximum=50, step=1, value=28)
+                    
+                    with gr.Row():
+                        width = gr.Slider(label="Width", minimum=256, maximum=1536, step=64, value=1024)
+                        height = gr.Slider(label="Height", minimum=256, maximum=1536, step=64, value=1024)
+                    
+                    with gr.Row():
+                        randomize_seed = gr.Checkbox(True, label="Randomize seed")
+                        seed = gr.Slider(label="Seed", minimum=0, maximum=MAX_SEED, step=1, value=0, randomize=True)
+                        lora_scale = gr.Slider(label="LoRA Scale", minimum=0, maximum=3, step=0.01, value=0.95)
+    
+        gallery.select(
+            update_selection,
+            inputs=[width, height],
+            outputs=[prompt, selected_info, selected_index, width, height]
+        )
+        custom_lora.input(
+            add_custom_lora,
+            inputs=[custom_lora],
+            outputs=[custom_lora_info, custom_lora_button, gallery, selected_info, selected_index, prompt]
+        )
+        custom_lora_button.click(
+            remove_custom_lora,
+            outputs=[custom_lora_info, custom_lora_button, gallery, selected_info, selected_index, custom_lora]
+        )
+        gr.on(
+            triggers=[generate_button.click, prompt.submit],
+            fn=run_lora,
+            inputs=[prompt, input_image, image_strength, cfg_scale, steps, selected_index, randomize_seed, seed, width, height, lora_scale],
+            outputs=[result, seed, progress_bar]
+    )
     return app
 
+
 if __name__ == "__main__":
-    app.queue()
-    app.launch(mcp_server=True, ssr_mode=False, show_error=True)
+    create_app().queue().launch(mcp_server=True, ssr_mode=False, show_error=True)

--- a/faceswap/app.py
+++ b/faceswap/app.py
@@ -12,6 +12,8 @@ import insightface
 import onnxruntime
 import numpy as np
 import gradio as gr
+__all__ = ["create_app"]
+
 import threading
 import queue
 from tqdm import tqdm
@@ -542,358 +544,356 @@ css = """
 footer{display:none !important}
 """
 
-with gr.Blocks(css=css) as interface:
-    gr.Markdown("# 🗿 Free Face Swapper")
-    gr.Markdown("### Help us keep this app free with a tip.")
-    with gr.Row():
+def create_app():
+    with gr.Blocks(css=css) as interface:
+        gr.Markdown("# 🗿 Free Face Swapper")
+        gr.Markdown("### Help us keep this app free with a tip.")
         with gr.Row():
-            with gr.Column(scale=0.4):
-                with gr.Tab("📄 Swap Condition"):
-                    swap_option = gr.Dropdown(
-                        swap_options_list,
-                        info="Choose which face or faces in the target image to swap.",
-                        multiselect=False,
-                        show_label=False,
-                        value=swap_options_list[0],
-                        interactive=True,
-                    )
-                    age = gr.Number(
-                        value=25, label="Value", interactive=True, visible=False
-                    )
-
-                with gr.Tab("🎚️ Detection Settings"):
-                    detect_condition_dropdown = gr.Dropdown(
-                        detect_conditions,
-                        label="Condition",
-                        value=DETECT_CONDITION,
-                        interactive=True,
-                        info="This condition is only used when multiple faces are detected on source or specific image.",
-                    )
-                    detection_size = gr.Number(
-                        label="Detection Size", value=DETECT_SIZE, interactive=True
-                    )
-                    detection_threshold = gr.Number(
-                        label="Detection Threshold",
-                        value=DETECT_THRESH,
-                        interactive=True,
-                    )
-                    apply_detection_settings = gr.Button("Apply settings")
-
-                with gr.Tab("📤 Output Settings"):
-                    output_directory = gr.Text(
-                        label="Output Directory",
-                        value=DEF_OUTPUT_PATH,
-                        interactive=True,
-                    )
-                    output_name = gr.Text(
-                        label="Output Name", value="Result", interactive=True
-                    )
-                    keep_output_sequence = gr.Checkbox(
-                        label="Keep output sequence", value=False, interactive=True
-                    )
-
-                with gr.Tab("🪄 Other Settings"):
-                    face_scale = gr.Slider(
-                        label="Face Scale",
-                        minimum=0,
-                        maximum=2,
-                        value=1,
-                        interactive=True,
-                    )
-
-                    face_enhancer_name = gr.Dropdown(
-                        FACE_ENHANCER_LIST, label="Face Enhancer", value="NONE", multiselect=False, interactive=True
-                    )
-
-                    with gr.Accordion("Advanced Mask", open=False):
-                        enable_face_parser_mask = gr.Checkbox(
-                            label="Enable Face Parsing",
-                            value=False,
+            with gr.Row():
+                with gr.Column(scale=0.4):
+                    with gr.Tab("📄 Swap Condition"):
+                        swap_option = gr.Dropdown(
+                            swap_options_list,
+                            info="Choose which face or faces in the target image to swap.",
+                            multiselect=False,
+                            show_label=False,
+                            value=swap_options_list[0],
                             interactive=True,
                         )
-
-                        mask_include = gr.Dropdown(
-                            mask_regions.keys(),
-                            value=MASK_INCLUDE,
-                            multiselect=True,
-                            label="Include",
+                        age = gr.Number(
+                            value=25, label="Value", interactive=True, visible=False
+                        )
+    
+                    with gr.Tab("🎚️ Detection Settings"):
+                        detect_condition_dropdown = gr.Dropdown(
+                            detect_conditions,
+                            label="Condition",
+                            value=DETECT_CONDITION,
+                            interactive=True,
+                            info="This condition is only used when multiple faces are detected on source or specific image.",
+                        )
+                        detection_size = gr.Number(
+                            label="Detection Size", value=DETECT_SIZE, interactive=True
+                        )
+                        detection_threshold = gr.Number(
+                            label="Detection Threshold",
+                            value=DETECT_THRESH,
                             interactive=True,
                         )
-                        mask_soft_kernel = gr.Number(
-                            label="Soft Erode Kernel",
-                            value=MASK_SOFT_KERNEL,
-                            minimum=3,
+                        apply_detection_settings = gr.Button("Apply settings")
+    
+                    with gr.Tab("📤 Output Settings"):
+                        output_directory = gr.Text(
+                            label="Output Directory",
+                            value=DEF_OUTPUT_PATH,
                             interactive=True,
-                            visible = False
                         )
-                        mask_soft_iterations = gr.Number(
-                            label="Soft Erode Iterations",
-                            value=MASK_SOFT_ITERATIONS,
+                        output_name = gr.Text(
+                            label="Output Name", value="Result", interactive=True
+                        )
+                        keep_output_sequence = gr.Checkbox(
+                            label="Keep output sequence", value=False, interactive=True
+                        )
+    
+                    with gr.Tab("🪄 Other Settings"):
+                        face_scale = gr.Slider(
+                            label="Face Scale",
                             minimum=0,
-                            interactive=True,
-
-                        )
-
-
-                    with gr.Accordion("Crop Mask", open=False):
-                        crop_top = gr.Slider(label="Top", minimum=0, maximum=511, value=0, step=1, interactive=True)
-                        crop_bott = gr.Slider(label="Bottom", minimum=0, maximum=511, value=511, step=1, interactive=True)
-                        crop_left = gr.Slider(label="Left", minimum=0, maximum=511, value=0, step=1, interactive=True)
-                        crop_right = gr.Slider(label="Right", minimum=0, maximum=511, value=511, step=1, interactive=True)
-
-
-                    erode_amount = gr.Slider(
-                            label="Mask Erode",
-                            minimum=0,
-                            maximum=1,
-                            value=MASK_ERODE_AMOUNT,
-                            step=0.05,
+                            maximum=2,
+                            value=1,
                             interactive=True,
                         )
-
-                    blur_amount = gr.Slider(
-                            label="Mask Blur",
-                            minimum=0,
-                            maximum=1,
-                            value=MASK_BLUR_AMOUNT,
-                            step=0.05,
-                            interactive=True,
+    
+                        face_enhancer_name = gr.Dropdown(
+                            FACE_ENHANCER_LIST, label="Face Enhancer", value="NONE", multiselect=False, interactive=True
                         )
-
-                    enable_laplacian_blend = gr.Checkbox(
-                        label="Laplacian Blending",
-                        value=True,
-                        interactive=True,
-                    )
-
-
-                source_image_input = gr.Image(
-                    label="Source face", type="filepath", interactive=True
-                )
-
-                with gr.Box(visible=False) as specific_face:
-                    for i in range(NUM_OF_SRC_SPECIFIC):
-                        idx = i + 1
-                        code = "\n"
-                        code += f"with gr.Tab(label='({idx})'):"
-                        code += "\n\twith gr.Row():"
-                        code += f"\n\t\tsrc{idx} = gr.Image(interactive=True, type='numpy', label='Source Face {idx}')"
-                        code += f"\n\t\ttrg{idx} = gr.Image(interactive=True, type='numpy', label='Specific Face {idx}')"
-                        exec(code)
-
-                    distance_slider = gr.Slider(
-                        minimum=0,
-                        maximum=2,
-                        value=0.6,
-                        interactive=True,
-                        label="Distance",
-                        info="Lower distance is more similar and higher distance is less similar to the target face.",
-                    )
-
-                with gr.Group():
-                    input_type = gr.Radio(
-                        ["Image", "Video"],
-                        label="Target Type",
-                        value="Image",
-                    )
-
-                    with gr.Box(visible=True) as input_image_group:
-                        image_input = gr.Image(
-                            label="Target Image", interactive=True, type="filepath"
-                        )
-
-                    with gr.Box(visible=False) as input_video_group:
-                        vid_widget = gr.Video if USE_COLAB else gr.Text
-                        video_input = gr.Video(
-                            label="Target Video", interactive=True
-                        )
-                        with gr.Accordion("✂️ Trim video", open=False):
-                            with gr.Column():
-                                with gr.Row():
-                                    set_slider_range_btn = gr.Button(
-                                        "Set frame range", interactive=True
-                                    )
-                                    show_trim_preview_btn = gr.Checkbox(
-                                        label="Show frame when slider change",
-                                        value=True,
-                                        interactive=True,
-                                    )
-
-                                video_fps = gr.Number(
-                                    value=30,
-                                    interactive=False,
-                                    label="Fps",
-                                    visible=False,
-                                )
-                                start_frame = gr.Slider(
-                                    minimum=0,
-                                    maximum=1,
-                                    value=0,
-                                    step=1,
-                                    interactive=True,
-                                    label="Start Frame",
-                                    info="",
-                                )
-                                end_frame = gr.Slider(
-                                    minimum=0,
-                                    maximum=1,
-                                    value=1,
-                                    step=1,
-                                    interactive=True,
-                                    label="End Frame",
-                                    info="",
-                                )
-                            trim_and_reload_btn = gr.Button(
-                                "Trim and Reload", interactive=True
+    
+                        with gr.Accordion("Advanced Mask", open=False):
+                            enable_face_parser_mask = gr.Checkbox(
+                                label="Enable Face Parsing",
+                                value=False,
+                                interactive=True,
                             )
-
-                    with gr.Box(visible=False) as input_directory_group:
-                        direc_input = gr.Text(label="Path", interactive=True)
-
-            with gr.Column(scale=0.6):
-                info = gr.Markdown(value="...")
-
-                with gr.Row():
-                    swap_button = gr.Button("✨ Swap", variant="primary")
-                    cancel_button = gr.Button("⛔ Cancel")
-
-                preview_image = gr.Image(label="Output", interactive=False)
-                preview_video = gr.Video(
-                    label="Output", interactive=False, visible=False
-                )
-
-                with gr.Row():
-                    output_directory_button = gr.Button(
-                        "📂", interactive=False, visible=False
-                    )
-                    output_video_button = gr.Button(
-                        "🎬", interactive=False, visible=False
-                    )
-
-                with gr.Box():
-                    with gr.Row():
-                        gr.Markdown(
-                            "### [🤝 Enjoying? Help us keep it free with a tip 🤗](https://www.paypal.com/donate/?hosted_button_id=WUWBM97N8EENN)"
+    
+                            mask_include = gr.Dropdown(
+                                mask_regions.keys(),
+                                value=MASK_INCLUDE,
+                                multiselect=True,
+                                label="Include",
+                                interactive=True,
+                            )
+                            mask_soft_kernel = gr.Number(
+                                label="Soft Erode Kernel",
+                                value=MASK_SOFT_KERNEL,
+                                minimum=3,
+                                interactive=True,
+                                visible = False
+                            )
+                            mask_soft_iterations = gr.Number(
+                                label="Soft Erode Iterations",
+                                value=MASK_SOFT_ITERATIONS,
+                                minimum=0,
+                                interactive=True,
+    
+                            )
+    
+    
+                        with gr.Accordion("Crop Mask", open=False):
+                            crop_top = gr.Slider(label="Top", minimum=0, maximum=511, value=0, step=1, interactive=True)
+                            crop_bott = gr.Slider(label="Bottom", minimum=0, maximum=511, value=511, step=1, interactive=True)
+                            crop_left = gr.Slider(label="Left", minimum=0, maximum=511, value=0, step=1, interactive=True)
+                            crop_right = gr.Slider(label="Right", minimum=0, maximum=511, value=511, step=1, interactive=True)
+    
+    
+                        erode_amount = gr.Slider(
+                                label="Mask Erode",
+                                minimum=0,
+                                maximum=1,
+                                value=MASK_ERODE_AMOUNT,
+                                step=0.05,
+                                interactive=True,
+                            )
+    
+                        blur_amount = gr.Slider(
+                                label="Mask Blur",
+                                minimum=0,
+                                maximum=1,
+                                value=MASK_BLUR_AMOUNT,
+                                step=0.05,
+                                interactive=True,
+                            )
+    
+                        enable_laplacian_blend = gr.Checkbox(
+                            label="Laplacian Blending",
+                            value=True,
+                            interactive=True,
                         )
-                        
-
-    ## ------------------------------ GRADIO EVENTS ------------------------------
-
-    set_slider_range_event = set_slider_range_btn.click(
-        video_changed,
-        inputs=[video_input],
-        outputs=[start_frame, end_frame, video_fps],
-    )
-
-    trim_and_reload_event = trim_and_reload_btn.click(
-        fn=trim_and_reload,
-        inputs=[video_input, output_directory, output_name, start_frame, end_frame],
-        outputs=[video_input, info],
-    )
-
-    start_frame_event = start_frame.release(
-        fn=slider_changed,
-        inputs=[show_trim_preview_btn, video_input, start_frame],
-        outputs=[preview_image, preview_video],
-        show_progress=True,
-    )
-
-    end_frame_event = end_frame.release(
-        fn=slider_changed,
-        inputs=[show_trim_preview_btn, video_input, end_frame],
-        outputs=[preview_image, preview_video],
-        show_progress=True,
-    )
-
-    input_type.change(
-        update_radio,
-        inputs=[input_type],
-        outputs=[input_image_group, input_video_group, input_directory_group],
-    )
-    swap_option.change(
-        swap_option_changed,
-        inputs=[swap_option],
-        outputs=[age, specific_face, source_image_input],
-    )
-
-    apply_detection_settings.click(
-        analyse_settings_changed,
-        inputs=[detect_condition_dropdown, detection_size, detection_threshold],
-        outputs=[info],
-    )
-
-    src_specific_inputs = []
-    gen_variable_txt = ",".join(
-        [f"src{i+1}" for i in range(NUM_OF_SRC_SPECIFIC)]
-        + [f"trg{i+1}" for i in range(NUM_OF_SRC_SPECIFIC)]
-    )
-    exec(f"src_specific_inputs = ({gen_variable_txt})")
-    swap_inputs = [
-        input_type,
-        image_input,
-        video_input,
-        direc_input,
-        source_image_input,
-        output_directory,
-        output_name,
-        keep_output_sequence,
-        swap_option,
-        age,
-        distance_slider,
-        face_enhancer_name,
-        enable_face_parser_mask,
-        mask_include,
-        mask_soft_kernel,
-        mask_soft_iterations,
-        blur_amount,
-        erode_amount,
-        face_scale,
-        enable_laplacian_blend,
-        crop_top,
-        crop_bott,
-        crop_left,
-        crop_right,
-        *src_specific_inputs,
-    ]
-
-    swap_outputs = [
-        info,
-        preview_image,
-        output_directory_button,
-        output_video_button,
-        preview_video,
-    ]
-
-    swap_event = swap_button.click(
-        fn=process, inputs=swap_inputs, outputs=swap_outputs, show_progress=True
-    )
-
-    cancel_button.click(
-        fn=stop_running,
-        inputs=None,
-        outputs=[info],
-        cancels=[
-            swap_event,
-            trim_and_reload_event,
-            set_slider_range_event,
-            start_frame_event,
-            end_frame_event,
-        ],
-        show_progress=True,
-    )
-    output_directory_button.click(
-        lambda: open_directory(path=WORKSPACE), inputs=None, outputs=None
-    )
-    output_video_button.click(
+    
+    
+                    source_image_input = gr.Image(
+                        label="Source face", type="filepath", interactive=True
+                    )
+    
+                    with gr.Box(visible=False) as specific_face:
+                        for i in range(NUM_OF_SRC_SPECIFIC):
+                            idx = i + 1
+                            code = "\n"
+                            code += f"with gr.Tab(label='({idx})'):"
+                            code += "\n\twith gr.Row():"
+                            code += f"\n\t\tsrc{idx} = gr.Image(interactive=True, type='numpy', label='Source Face {idx}')"
+                            code += f"\n\t\ttrg{idx} = gr.Image(interactive=True, type='numpy', label='Specific Face {idx}')"
+                            exec(code)
+    
+                        distance_slider = gr.Slider(
+                            minimum=0,
+                            maximum=2,
+                            value=0.6,
+                            interactive=True,
+                            label="Distance",
+                            info="Lower distance is more similar and higher distance is less similar to the target face.",
+                        )
+    
+                    with gr.Group():
+                        input_type = gr.Radio(
+                            ["Image", "Video"],
+                            label="Target Type",
+                            value="Image",
+                        )
+    
+                        with gr.Box(visible=True) as input_image_group:
+                            image_input = gr.Image(
+                                label="Target Image", interactive=True, type="filepath"
+                            )
+    
+                        with gr.Box(visible=False) as input_video_group:
+                            vid_widget = gr.Video if USE_COLAB else gr.Text
+                            video_input = gr.Video(
+                                label="Target Video", interactive=True
+                            )
+                            with gr.Accordion("✂️ Trim video", open=False):
+                                with gr.Column():
+                                    with gr.Row():
+                                        set_slider_range_btn = gr.Button(
+                                            "Set frame range", interactive=True
+                                        )
+                                        show_trim_preview_btn = gr.Checkbox(
+                                            label="Show frame when slider change",
+                                            value=True,
+                                            interactive=True,
+                                        )
+    
+                                    video_fps = gr.Number(
+                                        value=30,
+                                        interactive=False,
+                                        label="Fps",
+                                        visible=False,
+                                    )
+                                    start_frame = gr.Slider(
+                                        minimum=0,
+                                        maximum=1,
+                                        value=0,
+                                        step=1,
+                                        interactive=True,
+                                        label="Start Frame",
+                                        info="",
+                                    )
+                                    end_frame = gr.Slider(
+                                        minimum=0,
+                                        maximum=1,
+                                        value=1,
+                                        step=1,
+                                        interactive=True,
+                                        label="End Frame",
+                                        info="",
+                                    )
+                                trim_and_reload_btn = gr.Button(
+                                    "Trim and Reload", interactive=True
+                                )
+    
+                        with gr.Box(visible=False) as input_directory_group:
+                            direc_input = gr.Text(label="Path", interactive=True)
+    
+                with gr.Column(scale=0.6):
+                    info = gr.Markdown(value="...")
+    
+                    with gr.Row():
+                        swap_button = gr.Button("✨ Swap", variant="primary")
+                        cancel_button = gr.Button("⛔ Cancel")
+    
+                    preview_image = gr.Image(label="Output", interactive=False)
+                    preview_video = gr.Video(
+                        label="Output", interactive=False, visible=False
+                    )
+    
+                    with gr.Row():
+                        output_directory_button = gr.Button(
+                            "📂", interactive=False, visible=False
+                        )
+                        output_video_button = gr.Button(
+                            "🎬", interactive=False, visible=False
+                        )
+    
+                    with gr.Box():
+                        with gr.Row():
+                            gr.Markdown(
+                                "### [🤝 Enjoying? Help us keep it free with a tip 🤗](https://www.paypal.com/donate/?hosted_button_id=WUWBM97N8EENN)"
+                            )
+                            
+    
+        ## ------------------------------ GRADIO EVENTS ------------------------------
+    
+        set_slider_range_event = set_slider_range_btn.click(
+            video_changed,
+            inputs=[video_input],
+            outputs=[start_frame, end_frame, video_fps],
+        )
+    
+        trim_and_reload_event = trim_and_reload_btn.click(
+            fn=trim_and_reload,
+            inputs=[video_input, output_directory, output_name, start_frame, end_frame],
+            outputs=[video_input, info],
+        )
+    
+        start_frame_event = start_frame.release(
+            fn=slider_changed,
+            inputs=[show_trim_preview_btn, video_input, start_frame],
+            outputs=[preview_image, preview_video],
+            show_progress=True,
+        )
+    
+        end_frame_event = end_frame.release(
+            fn=slider_changed,
+            inputs=[show_trim_preview_btn, video_input, end_frame],
+            outputs=[preview_image, preview_video],
+            show_progress=True,
+        )
+    
+        input_type.change(
+            update_radio,
+            inputs=[input_type],
+            outputs=[input_image_group, input_video_group, input_directory_group],
+        )
+        swap_option.change(
+            swap_option_changed,
+            inputs=[swap_option],
+            outputs=[age, specific_face, source_image_input],
+        )
+    
+        apply_detection_settings.click(
+            analyse_settings_changed,
+            inputs=[detect_condition_dropdown, detection_size, detection_threshold],
+            outputs=[info],
+        )
+    
+        src_specific_inputs = []
+        gen_variable_txt = ",".join(
+            [f"src{i+1}" for i in range(NUM_OF_SRC_SPECIFIC)]
+            + [f"trg{i+1}" for i in range(NUM_OF_SRC_SPECIFIC)]
+        )
+        exec(f"src_specific_inputs = ({gen_variable_txt})")
+        swap_inputs = [
+            input_type,
+            image_input,
+            video_input,
+            direc_input,
+            source_image_input,
+            output_directory,
+            output_name,
+            keep_output_sequence,
+            swap_option,
+            age,
+            distance_slider,
+            face_enhancer_name,
+            enable_face_parser_mask,
+            mask_include,
+            mask_soft_kernel,
+            mask_soft_iterations,
+            blur_amount,
+            erode_amount,
+            face_scale,
+            enable_laplacian_blend,
+            crop_top,
+            crop_bott,
+            crop_left,
+            crop_right,
+            *src_specific_inputs,
+        ]
+    
+        swap_outputs = [
+            info,
+            preview_image,
+            output_directory_button,
+            output_video_button,
+            preview_video,
+        ]
+    
+        swap_event = swap_button.click(
+            fn=process, inputs=swap_inputs, outputs=swap_outputs, show_progress=True
+        )
+    
+        cancel_button.click(
+            fn=stop_running,
+            inputs=None,
+            outputs=[info],
+            cancels=[
+                swap_event,
+                trim_and_reload_event,
+                set_slider_range_event,
+                start_frame_event,
+                end_frame_event,
+            ],
+            show_progress=True,
+        )
+        output_directory_button.click(
+            lambda: open_directory(path=WORKSPACE), inputs=None, outputs=None
+        )
+        output_video_button.click(
         lambda: open_directory(path=OUTPUT_FILE), inputs=None, outputs=None
     )
-
-def create_app():
     return interface
 
-if __name__ == "__main__":
-    if USE_COLAB:
-        print("Running in colab mode")
 
-    interface.queue(concurrency_count=2, max_size=20).launch(share=USE_COLAB)
+
+if __name__ == "__main__":
+    create_app().queue(concurrency_count=2, max_size=20).launch(share=USE_COLAB)
 

--- a/self-forcing/app.py
+++ b/self-forcing/app.py
@@ -29,6 +29,8 @@ from PIL import Image
 import spaces
 import torch
 import gradio as gr
+__all__ = ["create_app"]
+
 from omegaconf import OmegaConf
 from tqdm import tqdm
 import imageio
@@ -421,89 +423,88 @@ def video_generation_handler_streaming(prompt, seed=42, fps=15):
     yield None, final_status_html
     print(f"✅ PyAV streaming complete! {total_frames_yielded} frames across {num_blocks} blocks")
 
-# --- Gradio UI Layout ---
-with gr.Blocks(title="Self-Forcing Streaming Demo") as demo:
-    gr.Markdown("# 🚀 Self-Forcing Video Generation")
-    gr.Markdown("Real-time video generation with distilled Wan2-1 1.3B [[Model]](https://huggingface.co/gdhe17/Self-Forcing), [[Project page]](https://self-forcing.github.io), [[Paper]](https://huggingface.co/papers/2506.08009)")
-    
-    with gr.Row():
-        with gr.Column(scale=2):
-            with gr.Group():
-                prompt = gr.Textbox(
-                    label="Prompt", 
-                    placeholder="A stylish woman walks down a Tokyo street...", 
-                    lines=4,
-                    value=""
-                )
-                enhance_button = gr.Button("✨ Enhance Prompt", variant="secondary")
-
-            start_btn = gr.Button("🎬 Start Streaming", variant="primary", size="lg")
-            
-            gr.Markdown("### 🎯 Examples")
-            gr.Examples(
-                examples=[
-                    "A close-up shot of a ceramic teacup slowly pouring water into a glass mug.",
-                    "A playful cat is seen playing an electronic guitar, strumming the strings with its front paws. The cat has distinctive black facial markings and a bushy tail. It sits comfortably on a small stool, its body slightly tilted as it focuses intently on the instrument. The setting is a cozy, dimly lit room with vintage posters on the walls, adding a retro vibe. The cat's expressive eyes convey a sense of joy and concentration. Medium close-up shot, focusing on the cat's face and hands interacting with the guitar.",
-                    "A dynamic over-the-shoulder perspective of a chef meticulously plating a dish in a bustling kitchen. The chef, a middle-aged woman, deftly arranges ingredients on a pristine white plate. Her hands move with precision, each gesture deliberate and practiced. The background shows a crowded kitchen with steaming pots, whirring blenders, and the clatter of utensils. Bright lights highlight the scene, casting shadows across the busy workspace. The camera angle captures the chef's detailed work from behind, emphasizing his skill and dedication.",
-                ],
-                inputs=[prompt],
-            )
-            
-            gr.Markdown("### ⚙️ Settings")
-            with gr.Row():
-                seed = gr.Number(
-                    label="Seed", 
-                    value=-1, 
-                    info="Use -1 for random seed",
-                    precision=0
-                )
-                fps = gr.Slider(
-                    label="Playback FPS", 
-                    minimum=1, 
-                    maximum=30, 
-                    value=args.fps, 
-                    step=1,
-                    visible=False,
-                    info="Frames per second for playback"
-                )
-            
-        with gr.Column(scale=3):
-            gr.Markdown("### 📺 Video Stream")
-
-            streaming_video = gr.Video(
-                label="Live Stream",
-                streaming=True,
-                loop=True,
-                height=400,
-                autoplay=True,
-                show_label=False
-            )
-            
-            status_display = gr.HTML(
-                value=(
-                    "<div style='text-align: center; padding: 20px; color: #666; border: 1px dashed #ddd; border-radius: 8px;'>"
-                    "🎬 Ready to start streaming...<br>"
-                    "<small>Configure your prompt and click 'Start Streaming'</small>"
-                    "</div>"
-                ),
-                label="Generation Status"
-            )
-
-    # Connect the generator to the streaming video
-    start_btn.click(
-        fn=video_generation_handler_streaming,
-        inputs=[prompt, seed, fps],
-        outputs=[streaming_video, status_display]
-    )
-    
-    enhance_button.click(
-        fn=enhance_prompt,
-        inputs=[prompt],
-        outputs=[prompt]
-    )
-
-# --- Launch App ---
 def create_app():
+    # --- Gradio UI Layout ---
+    with gr.Blocks(title="Self-Forcing Streaming Demo") as demo:
+        gr.Markdown("# 🚀 Self-Forcing Video Generation")
+        gr.Markdown("Real-time video generation with distilled Wan2-1 1.3B [[Model]](https://huggingface.co/gdhe17/Self-Forcing), [[Project page]](https://self-forcing.github.io), [[Paper]](https://huggingface.co/papers/2506.08009)")
+        
+        with gr.Row():
+            with gr.Column(scale=2):
+                with gr.Group():
+                    prompt = gr.Textbox(
+                        label="Prompt", 
+                        placeholder="A stylish woman walks down a Tokyo street...", 
+                        lines=4,
+                        value=""
+                    )
+                    enhance_button = gr.Button("✨ Enhance Prompt", variant="secondary")
+    
+                start_btn = gr.Button("🎬 Start Streaming", variant="primary", size="lg")
+                
+                gr.Markdown("### 🎯 Examples")
+                gr.Examples(
+                    examples=[
+                        "A close-up shot of a ceramic teacup slowly pouring water into a glass mug.",
+                        "A playful cat is seen playing an electronic guitar, strumming the strings with its front paws. The cat has distinctive black facial markings and a bushy tail. It sits comfortably on a small stool, its body slightly tilted as it focuses intently on the instrument. The setting is a cozy, dimly lit room with vintage posters on the walls, adding a retro vibe. The cat's expressive eyes convey a sense of joy and concentration. Medium close-up shot, focusing on the cat's face and hands interacting with the guitar.",
+                        "A dynamic over-the-shoulder perspective of a chef meticulously plating a dish in a bustling kitchen. The chef, a middle-aged woman, deftly arranges ingredients on a pristine white plate. Her hands move with precision, each gesture deliberate and practiced. The background shows a crowded kitchen with steaming pots, whirring blenders, and the clatter of utensils. Bright lights highlight the scene, casting shadows across the busy workspace. The camera angle captures the chef's detailed work from behind, emphasizing his skill and dedication.",
+                    ],
+                    inputs=[prompt],
+                )
+                
+                gr.Markdown("### ⚙️ Settings")
+                with gr.Row():
+                    seed = gr.Number(
+                        label="Seed", 
+                        value=-1, 
+                        info="Use -1 for random seed",
+                        precision=0
+                    )
+                    fps = gr.Slider(
+                        label="Playback FPS", 
+                        minimum=1, 
+                        maximum=30, 
+                        value=args.fps, 
+                        step=1,
+                        visible=False,
+                        info="Frames per second for playback"
+                    )
+                
+            with gr.Column(scale=3):
+                gr.Markdown("### 📺 Video Stream")
+    
+                streaming_video = gr.Video(
+                    label="Live Stream",
+                    streaming=True,
+                    loop=True,
+                    height=400,
+                    autoplay=True,
+                    show_label=False
+                )
+                
+                status_display = gr.HTML(
+                    value=(
+                        "<div style='text-align: center; padding: 20px; color: #666; border: 1px dashed #ddd; border-radius: 8px;'>"
+                        "🎬 Ready to start streaming...<br>"
+                        "<small>Configure your prompt and click 'Start Streaming'</small>"
+                        "</div>"
+                    ),
+                    label="Generation Status"
+                )
+    
+        # Connect the generator to the streaming video
+        start_btn.click(
+            fn=video_generation_handler_streaming,
+            inputs=[prompt, seed, fps],
+            outputs=[streaming_video, status_display]
+        )
+        
+        enhance_button.click(
+            fn=enhance_prompt,
+            inputs=[prompt],
+            outputs=[prompt]
+    )
+
     return demo
 
 if __name__ == "__main__":
@@ -517,7 +518,7 @@ if __name__ == "__main__":
     print(f"🎯 Chunk encoding: PyAV (MPEG-TS/H.264)")
     print(f"⚡ GPU acceleration: {gpu}")
 
-    demo.queue().launch(
+    create_app().queue().launch(
         server_name=args.host,
         server_port=args.port,
         share=args.share,


### PR DESCRIPTION
## Summary
- add `__all__` exports for clean imports
- turn the UI builders in `app.py` files into `create_app()` factories
- use `create_app().queue().launch()` idiom for launching apps

## Testing
- `python -m py_compile Character-Generator/app.py FLUX-LoRA-DLC/app.py faceswap/app.py self-forcing/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686596ffc39c8330947631a0bfd8446f