### PR TITLE
Add model selection dropdown in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,8 @@ import gradio as gr
 import importlib.util
 import os
 
+from utils.ollama_client import AVAILABLE_MODELS, set_model, get_model
+
 
 def load_create_app(module_name, file_path):
     spec = importlib.util.spec_from_file_location(module_name, file_path)
@@ -14,17 +16,34 @@ flux_create_app = load_create_app('flux_lora_dlc', os.path.join('FLUX-LoRA-DLC',
 faceswap_create_app = load_create_app('faceswap', os.path.join('faceswap', 'app.py'))
 selfforcing_create_app = load_create_app('self_forcing', os.path.join('self-forcing', 'app.py'))
 
+
+def create_settings_app():
+    """Settings tab with model selection."""
+    with gr.Blocks() as app:
+        gr.Markdown("## Settings")
+        model_dropdown = gr.Dropdown(
+            choices=AVAILABLE_MODELS,
+            value=get_model(),
+            label="Ollama Model",
+        )
+
+        model_dropdown.change(set_model, inputs=model_dropdown, outputs=None)
+
+    return app
+
 apps = [
     character_create_app(),
     flux_create_app(),
     faceswap_create_app(),
     selfforcing_create_app(),
+    create_settings_app(),
 ]
 labels = [
     'Character Generator',
     'FLUX LoRA DLC',
     'FaceSwap',
     'Self-Forcing',
+    'Settings',
 ]
 
 demo = gr.TabbedInterface(apps, labels)

--- a/utils/ollama_client.py
+++ b/utils/ollama_client.py
@@ -1,13 +1,33 @@
 import os
 import requests
 
+__all__ = [
+    "AVAILABLE_MODELS",
+    "set_model",
+    "get_model",
+    "generate",
+]
+
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
-_current_model = None
+
+# List of models available to all apps using this client
+AVAILABLE_MODELS = [
+    "llama3",
+    "mistral",
+]
+
+# Currently selected model
+_current_model = os.environ.get("OLLAMA_MODEL", AVAILABLE_MODELS[0])
 
 def set_model(name: str):
     """Set the default model name used for generation."""
     global _current_model
     _current_model = name
+
+
+def get_model() -> str:
+    """Return the currently selected model name."""
+    return _current_model
 
 
 def generate(prompt: str, model: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- manage Ollama model choice centrally
- expose list of models in `utils/ollama_client`
- add Settings tab in dashboard with dropdown

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68659e122bf083309cf6c13baf0b12ec