### PR TITLE
Add cache_dir helper for model downloads

### DIFF
--- a/Character-Generator/app.py
+++ b/Character-Generator/app.py
@@ -6,6 +6,7 @@ from diffusers import FluxPipeline, AutoencoderKL
 from live_preview_helpers import flux_pipe_call_that_returns_an_iterable_of_images
 from pydantic import BaseModel
 from utils.ollama_client import generate
+from utils.cache import get_cache_dir
 
 __all__ = ["create_app"]
 
@@ -22,8 +23,17 @@ class CharacterDescription(BaseModel):
     current_situation: str
     spoken_lines: list[str]
 
-pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16).to(device)
-good_vae = AutoencoderKL.from_pretrained("black-forest-labs/FLUX.1-dev", subfolder="vae", torch_dtype=torch.bfloat16).to(device)
+pipe = FluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-dev",
+    torch_dtype=torch.bfloat16,
+    cache_dir=get_cache_dir(),
+).to(device)
+good_vae = AutoencoderKL.from_pretrained(
+    "black-forest-labs/FLUX.1-dev",
+    subfolder="vae",
+    torch_dtype=torch.bfloat16,
+    cache_dir=get_cache_dir(),
+).to(device)
 # pipe.enable_sequential_cpu_offload()
 # pipe.vae.enable_slicing()
 # pipe.vae.enable_tiling()

--- a/FLUX-LoRA-DLC/app.py
+++ b/FLUX-LoRA-DLC/app.py
@@ -28,6 +28,7 @@ from huggingface_hub import (
     snapshot_download)
 
 from diffusers.utils import load_image
+from utils.cache import get_cache_dir
 
 
 # Authenticate with Hugging Face
@@ -2099,16 +2100,32 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 base_model = "black-forest-labs/FLUX.1-dev"
 
 #TAEF1 is very tiny autoencoder which uses the same "latent API" as FLUX.1's VAE. FLUX.1 is useful for real-time previewing of the FLUX.1 generation process.#
-taef1 = AutoencoderTiny.from_pretrained("madebyollin/taef1", torch_dtype=dtype).to(device)
-good_vae = AutoencoderKL.from_pretrained(base_model, subfolder="vae", torch_dtype=dtype).to(device)
-pipe = DiffusionPipeline.from_pretrained(base_model, torch_dtype=dtype, vae=taef1).to(device)
-pipe_i2i = AutoPipelineForImage2Image.from_pretrained(base_model,
+taef1 = AutoencoderTiny.from_pretrained(
+    "madebyollin/taef1",
+    torch_dtype=dtype,
+    cache_dir=get_cache_dir(),
+).to(device)
+good_vae = AutoencoderKL.from_pretrained(
+    base_model,
+    subfolder="vae",
+    torch_dtype=dtype,
+    cache_dir=get_cache_dir(),
+).to(device)
+pipe = DiffusionPipeline.from_pretrained(
+    base_model,
+    torch_dtype=dtype,
+    vae=taef1,
+    cache_dir=get_cache_dir(),
+).to(device)
+pipe_i2i = AutoPipelineForImage2Image.from_pretrained(
+    base_model,
                                                       vae=good_vae,
                                                       transformer=pipe.transformer,
                                                       text_encoder=pipe.text_encoder,
                                                       tokenizer=pipe.tokenizer,
                                                       text_encoder_2=pipe.text_encoder_2,
                                                       tokenizer_2=pipe.tokenizer_2,
+                                                      cache_dir=get_cache_dir(),
                                                       torch_dtype=dtype
                                                      )
 

--- a/self-forcing/app.py
+++ b/self-forcing/app.py
@@ -2,20 +2,23 @@ import subprocess
 subprocess.run('pip install flash-attn --no-build-isolation', env={'FLASH_ATTENTION_SKIP_CUDA_BUILD': "TRUE"}, shell=True)
 
 from huggingface_hub import snapshot_download, hf_hub_download
+from utils.cache import get_cache_dir
 
 snapshot_download(
     repo_id="Wan-AI/Wan2.1-T2V-1.3B",
     local_dir="wan_models/Wan2.1-T2V-1.3B",
     local_dir_use_symlinks=False,
     resume_download=True,
-    repo_type="model" 
+    repo_type="model",
+    cache_dir=get_cache_dir(),
 )
 
 hf_hub_download(
     repo_id="gdhe17/Self-Forcing",
     filename="checkpoints/self_forcing_dmd.pt",
-    local_dir=".",              
-    local_dir_use_symlinks=False 
+    local_dir=".",
+    local_dir_use_symlinks=False,
+    cache_dir=get_cache_dir()
 )
 
 import os
@@ -46,15 +49,19 @@ import numpy as np
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-model_checkpoint = "Qwen/Qwen3-8B" 
+model_checkpoint = "Qwen/Qwen3-8B"
 
-tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
+tokenizer = AutoTokenizer.from_pretrained(
+    model_checkpoint,
+    cache_dir=get_cache_dir(),
+)
 
 model = AutoModelForCausalLM.from_pretrained(
     model_checkpoint,
-    torch_dtype=torch.bfloat16, 
+    torch_dtype=torch.bfloat16,
     attn_implementation="flash_attention_2",
-    device_map="auto"
+    device_map="auto",
+    cache_dir=get_cache_dir(),
 )
 enhancer = pipeline(
     'text-generation',

--- a/self-forcing/wan/modules/tokenizers.py
+++ b/self-forcing/wan/modules/tokenizers.py
@@ -5,6 +5,7 @@ import string
 import ftfy
 import regex as re
 from transformers import AutoTokenizer
+from utils.cache import get_cache_dir
 
 __all__ = ['HuggingfaceTokenizer']
 
@@ -43,7 +44,11 @@ class HuggingfaceTokenizer:
         self.clean = clean
 
         # init tokenizer
-        self.tokenizer = AutoTokenizer.from_pretrained(name, **kwargs)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            name,
+            cache_dir=get_cache_dir(),
+            **kwargs,
+        )
         self.vocab_size = self.tokenizer.vocab_size
 
     def __call__(self, sequence, **kwargs):

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,14 @@
+"""Utilities for managing model caches."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["get_cache_dir"]
+
+
+def get_cache_dir() -> str:
+    """Return the directory used to cache downloaded models."""
+    return os.environ.get("MODEL_CACHE", str(Path.home() / ".cache" / "creator"))
+


### PR DESCRIPTION
## Summary
- add `utils.cache.get_cache_dir` utility
- download huggingface models into the configured cache
- update Character Generator, FLUX-LoRA-DLC and Self‑Forcing apps to use the cache
- ensure tokenizer and prompt extension helpers use the same cache

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a671aa98833082f23f8e5afc4566