### PR TITLE
Clean up duplicate package pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-accelerate
 accelerate>=1.1.1
 av==13.1.0
 dashscope
 datasets
-diffusers
 diffusers==0.31.0
 dominate
 easydict
@@ -12,10 +10,7 @@ fastrtc==0.0.28
 flask
 flask-socketio
 ftfy
-git+https://github.com/huggingface/accelerate.git
-git+https://github.com/huggingface/diffusers.git
 git+https://github.com/huggingface/peft.git
-git+https://github.com/huggingface/transformers.git
 git+https://github.com/openai/CLIP.git
 gradio_client
 hf_xet
@@ -24,7 +19,6 @@ imageio
 imageio-ffmpeg
 lmdb
 matplotlib
-numpy
 numpy==1.24.4
 nvidia-tensorrt
 omegaconf
@@ -33,7 +27,6 @@ onnxconverter_common
 onnxruntime
 onnxscript
 open_clip_torch
-opencv-python
 opencv-python>=4.9.0.80
 pycocotools
 pydantic==2.10.6
@@ -42,11 +35,9 @@ scikit-image
 sentencepiece
 starlette
 tokenizers>=0.20.3
-torch
 torch>=2.4.0
 torchao
 torchvision>=0.19.0
 tqdm
-transformers
 transformers>=4.49.0
 wandb


### PR DESCRIPTION
## Summary
- remove redundant entries from `requirements.txt`
- keep single version for accelerate, diffusers, numpy, opencv-python, torch, and transformers

## Testing
- `python -m pip --version`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_6866700bf03483308dd554e206b57d4e