### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The apps can be launched together from a single dashboard.
 ## Setup
 
 1. Install Python 3.10 or later.
-2. Install the required packages:
+2. Run the setup script to install all dependencies:
    ```bash
-   pip install -r requirements.txt
+   ./setup.sh
    ```
 
 You can change the Ollama host by setting the `OLLAMA_HOST` environment variable

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Setup script for Creator Dashboard
+# Usage: ./setup.sh [--with-models]
+
+set -e
+
+# install main requirements
+pip install -r requirements.txt
+
+# install submodule requirements
+for req in Character-Generator/requirements.txt FLUX-LoRA-DLC/requirements.txt self-forcing/requirements.txt; do
+    if [ -f "$req" ]; then
+        pip install -r "$req"
+    fi
+done
+
+# optionally download models for self-forcing
+if [[ "$1" == "--with-models" ]]; then
+    python - <<'PY'
+from huggingface_hub import snapshot_download, hf_hub_download
+import os
+from pathlib import Path
+
+cache_dir = os.environ.get("MODEL_CACHE", str(Path.home() / ".cache" / "creator"))
+
+snapshot_download(
+    repo_id="Wan-AI/Wan2.1-T2V-1.3B",
+    local_dir="self-forcing/wan_models/Wan2.1-T2V-1.3B",
+    local_dir_use_symlinks=False,
+    resume_download=True,
+    repo_type="model",
+    cache_dir=cache_dir,
+)
+
+hf_hub_download(
+    repo_id="gdhe17/Self-Forcing",
+    filename="checkpoints/self_forcing_dmd.pt",
+    local_dir="self-forcing",
+    local_dir_use_symlinks=False,
+    cache_dir=cache_dir,
+)
+PY
+fi


### PR DESCRIPTION
## Summary
- add a `setup.sh` script to install all requirements and optionally pre-download models
- document using the setup script

## Testing
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `./setup.sh --with-models` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_686672bdca4c833096adca9db16a2453